### PR TITLE
Display crop factor modifiers in rotation planner

### DIFF
--- a/gui/InGameMenuCropRotationPlanner.lua
+++ b/gui/InGameMenuCropRotationPlanner.lua
@@ -13,7 +13,8 @@ InGameMenuCropRotationPlanner = {
         CROP_ELEMENTS = "cropElement",
         CROP_TEXTS = "cropText",
         CROP_ICONS = "cropIcon",
-        CROP_FACTORS = "cropFactor"
+        CROP_FACTORS = "cropFactor",
+        CROP_FACTORS_MULTIPLIERS = "cropFactorModifiers",
     },
     MAX_ROTATION_ELEMENTS = 8
 }
@@ -98,10 +99,10 @@ local function cr_unskip(orig, input)
     local result = {}
     for k, v in pairs(orig) do
         if v ~= -1 then
-            table.insert(result, string.format("%.2f", input[j]))
+            table.insert(result, input[j])
             j = 1 + j
         else
-            table.insert(result, "-")
+            table.insert(result, nil)
         end
     end
     return result
@@ -124,6 +125,8 @@ function InGameMenuCropRotationPlanner:updateRotation()
     for index, element in pairs(self.cropElement) do
         local elementText = self.cropText[index]
         local elementIcon = self.cropIcon[index]
+        local elementFactor = self.cropFactor[index]
+        local cropFactorModifiers = self.cropFactorModifiers[index]
 
         if element.cropIndex > 0 then
             local fruitIndex = self.cropIndexToFruitIndexMap[element.cropIndex].index
@@ -136,6 +139,21 @@ function InGameMenuCropRotationPlanner:updateRotation()
             elementIcon:setImageFilename(fruitDesc.fillType.hudOverlayFilename)
             elementIcon:setPosition(elementText.position[1] - textWidth * 0.5 - elementIcon.margin[3], nil)
             elementIcon:setVisible(true)
+
+            elementFactor:setText(string.format("%d %%", math.floor(100.0 * factors[index].factor + 0.1)))
+
+            local modifiers = {}
+            if factors[index].lastCropFactor ~= 0 or factors[index].prevCropFactor ~= 0 then
+                table.insert(modifiers, string.format("%+d %% / %+d %% (previous crops)", math.floor(100 * factors[index].lastCropFactor + 0.1), math.floor(100 * factors[index].prevCropFactor + 0.1)))
+            end
+            if factors[index].returnPeriodFactor ~= 0 then
+                table.insert(modifiers, string.format("%+d %% (return period)", math.floor(100 * factors[index].returnPeriodFactor + 0.1)))
+            end
+            if factors[index].monocultureFactor ~= 0 then
+                table.insert(modifiers, string.format("%+d %% (monoculture)", math.floor(100 * factors[index].monocultureFactor + 0.1)))
+            end
+
+            cropFactorModifiers:setText(table.concat(modifiers, "   "))
         else
             if element.cropIndex == 0 then
                 elementText:setText(g_i18n:getText("cropRotation_fallow"))
@@ -144,9 +162,10 @@ function InGameMenuCropRotationPlanner:updateRotation()
             end
 
             elementIcon:setVisible(false)
-        end
 
-        self.cropFactor[index]:setText(factors[index]) -- this is always valid
+            elementFactor:setText("--")
+            cropFactorModifiers:setText("")
+        end
 
         if index > 1 then
             element:setVisible(self.cropElement[index - 1].cropIndex >= 0) -- hide rotation elements after "nothing"

--- a/gui/InGameMenuCropRotationPlanner.xml
+++ b/gui/InGameMenuCropRotationPlanner.xml
@@ -19,6 +19,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[1]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[1]" text="1.14" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[1]" text="" />
                 </GuiElement>
 
                 <GuiElement type="multiTextOption" profile="multiTextOptionCR" onClick="onValueChanged" id="cropElement[2]" handleFocus="true">
@@ -28,6 +29,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[2]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[2]" text="1.14" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[2]" text="" />
                 </GuiElement>
 
                 <GuiElement type="multiTextOption" profile="multiTextOptionCR" onClick="onValueChanged" id="cropElement[3]" handleFocus="true">
@@ -37,6 +39,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[3]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[3]" text="1.13" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[3]" text="" />
                 </GuiElement>
 
                 <GuiElement type="multiTextOption" profile="multiTextOptionCR" onClick="onValueChanged" id="cropElement[4]" handleFocus="true">
@@ -46,6 +49,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[4]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[4]" text="1.12" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[4]" text="" />
                 </GuiElement>
 
                 <GuiElement type="multiTextOption" profile="multiTextOptionCR" onClick="onValueChanged" id="cropElement[5]" handleFocus="true">
@@ -55,6 +59,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[5]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[5]" text="1.11" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[5]" text="" />
                 </GuiElement>
 
                 <GuiElement type="multiTextOption" profile="multiTextOptionCR" onClick="onValueChanged" id="cropElement[6]" handleFocus="true">
@@ -64,6 +69,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[6]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[6]" text="1.10" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[6]" text="" />
                 </GuiElement>
 
                 <GuiElement type="multiTextOption" profile="multiTextOptionCR" onClick="onValueChanged" id="cropElement[7]" handleFocus="true">
@@ -73,6 +79,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[7]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[7]" text="1.10" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[7]" text="" />
                 </GuiElement>
 
                 <GuiElement type="multiTextOption" profile="multiTextOptionCR" onClick="onValueChanged" id="cropElement[8]" handleFocus="true">
@@ -82,6 +89,7 @@
                     <GuiElement type="bitmap" profile="multiTextOptionBg" />
                     <GuiElement type="bitmap" profile="multiTextOptionIconCR" id="cropIcon[8]"/>
                     <GuiElement type="text" profile="multiTextOptionLabelCR" id="cropFactor[8]" text="1.10" />
+                    <GuiElement type="text" profile="multiTextOptionSubLabelCR" id="cropFactorModifiers[8]" text="" />
                 </GuiElement>
 
             </GuiElement>

--- a/gui/guiProfiles.xml
+++ b/gui/guiProfiles.xml
@@ -12,14 +12,22 @@
     </Profile>
 
     <Profile name="multiTextOptionLabelCR" extends="multiTextOptionTitle" with="anchorBottomLeft">
-        <Value name="position" value="400px 6px" />
-
+        <Value name="position" value="400px 15px" />
         <Value name="textAlignment" value="right"/>
-        <Value name="textVerticalAlignment" value="bottom"/>
         <Value name="textSize" value="18px"/>
         <Value name="textMaxWidth" value="120px"/>
         <Value name="textBold" value="false"/>
         <Value name="textMaxNumLines" value="1"/>
+    </Profile>
+
+    <Profile name="multiTextOptionSubLabelCR" extends="multiTextOptionTitle" with="anchorBottomLeft">
+        <Value name="position" value="470px 15px" />
+        <Value name="textMaxWidth" value="800px"/>
+        <Value name="textAlignment" value="left"/>
+        <Value name="textSize" value="18px"/>
+        <Value name="textBold" value="false"/>
+        <Value name="textMaxNumLines" value="1"/>
+        <Value name="textColor" value="0.4 0.4 0.4 1" />
     </Profile>
 
     <Profile name="multiTextOptionIconCR" extends="baseReference" with="anchorMiddleCenter">


### PR DESCRIPTION
## Why

In the rotation planner
- display crop factor in %
- display crop factor modifiers as suggested in https://github.com/bodzio528/FS22_CropRotation/issues/18

![image](https://user-images.githubusercontent.com/1886834/210453125-9b4040b5-9e5e-430a-9d79-640e2a5bea77.png)

## Notes

I've no experience in lua scripting nor Farming Simulator modding, so it might not be perfect