### PR TITLE
Update modDesc.xml

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -132,8 +132,9 @@ Registro delle modifiche 2.1.0.3:
     <multiplayer supported="true"/>
 
     <extraSourceFiles>
+        <sourceFile filename="loadCustomLocalization/loadCustomLocalizationClientside.lua" />
         <sourceFile filename="main.lua"/>
     </extraSourceFiles>
-
+    <!-- Please see comment at the top in this modDesc.XML, about how to make your own local translation file, that must be placed in folder [..]/modSettings/FS22_CropRotation/ -->
     <l10n filenamePrefix="translations/translation" />
 </modDesc>


### PR DESCRIPTION
Possibility to make your own local translation, by placing a l10n.xml (localization.xml) file in
    the folder [..]/modSettings/FS22_CropRotation/   (you need to create the folder 'FS22_CropRotation', as it won't be created automatically)

    Take a copy of this mod's translation_en.xml file, and place into the folder [..]/modSettings/FS22_CropRotation/

    Rename the l10n_en.xml file, to use your choice of language code (de,fr,hu,ru,ch,...), or just use generic filename of  l10n.xml  (or localization.xml)

    Now you can edit your own local copy for a localization file for this mod, and when it is error-free, it will be loaded by a script in this mod when a game-session is started.